### PR TITLE
remove people detection results on ground to ignore shadow

### DIFF
--- a/docker/jetson-humble-base-src/Dockerfile
+++ b/docker/jetson-humble-base-src/Dockerfile
@@ -6,6 +6,9 @@ ARG ROS_PKG=ros_base
 ENV ROS_DISTRO=humble
 ENV ROS_ROOT=/opt/ros/${ROS_DISTRO}
 
+# CMake 3.20+ is required to build ROS2
+ARG CMAKE_V=3.20.6
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /tmp
@@ -61,6 +64,11 @@ RUN python3 -m pip install -U \
 	pytest-repeat \
 	pytest-rerunfailures \
 	pytest
+
+# install cmake
+RUN wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_V}/cmake-${CMAKE_V}-linux-aarch64.sh && \
+    sh cmake-${CMAKE_V}-linux-aarch64.sh --skip-license --prefix=/usr && \
+    rm cmake-${CMAKE_V}-linux-aarch64.sh
 
 # build ROS2
 RUN mkdir -p ${ROS_ROOT}/src && \

--- a/docker/jetson-humble-base-src/Dockerfile
+++ b/docker/jetson-humble-base-src/Dockerfile
@@ -91,6 +91,9 @@ RUN mkdir -p ${ROS_ROOT}/src && \
 	launch_ros \
 	rosidl_runtime_py \
 	tf_transformations \
+	pcl_conversions \
+	pcl_msgs \
+	pcl_ros \
 	> ros2.${ROS_DISTRO}.${ROS_PKG}.rosinstall && \
 	cat ros2.${ROS_DISTRO}.${ROS_PKG}.rosinstall && \
 	vcs import src < ros2.${ROS_DISTRO}.${ROS_PKG}.rosinstall && \


### PR DESCRIPTION
This pull request fixed the problem that shadow is recognized as a person (https://github.com/CMU-cabot/TODO-Consortium/issues/579).
People detection results on the ground is ignored by using the height of point cloud.