### PR TITLE
specify HesaiLidar_SDK_2.0 version in dependency.repos to fix vesion mismatch between HesaiLidar_ROS_2.0 and HesaiLidar_SDK_2.0

### DIFF
--- a/dependency.repos
+++ b/dependency.repos
@@ -19,7 +19,7 @@ repositories:
     # TODO: use vcs import < dependency.repos --recursive if the number of submodules becomes large
     type: git
     url: https://github.com/HesaiTechnology/HesaiLidar_SDK_2.0
-    version: master
+    version: af2cff7c89b09b0a848f15fd0fb2778ac2add6d0
   docker/humble-custom/Lslidar_ROS2_driver:
     type: git
     url: https://github.com/Lslidar/Lslidar_ROS2_driver.git


### PR DESCRIPTION
fix issue docker image build when using dependency.repos fails

https://github.com/CMU-cabot/TODO-Consortium/issues/974

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>